### PR TITLE
Add basic project information

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yaml
@@ -1,0 +1,42 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug] "
+labels: ["bug"]
+projects: ["Gold-Rush-Robotics/2"]
+assignees:
+  - dudebehinddude # assign it to PM to get a notif to sort/categorize it
+body:
+  - type: input
+    id: what
+    attributes:
+      label: WHAT IS ISSUE
+      description: What is wrong
+      placeholder: It's not working...
+    validations:
+      required: true
+  - type: textarea
+    id: how
+    attributes:
+      label: HOW DID HAPPEN
+      description: What happened to make the issue appear? The more detailed your breakdown is the easier it is to reproduce/debug/fix
+      placeholder: |
+        1. Turned on robot
+        2. Robot moved
+        3. Error happened
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is it that this issue gets fixed? (Take your best guess)
+      options:
+        - High (blocking major development)
+        - Medium
+        - Low
+  - type: textarea
+    id: misc
+    attributes:
+      label: OTHER INFORMATION
+      description: Attach other useful information (i.e., a video of what happened) here. The more info we have the easier it should be to fix.
+      placeholder: "Here is a video of what is happening: (you can click here and drag and drop or paste to upload media)"

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yaml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: Request something to be added to the robot
+title: "[Bug] "
+labels: ["enhancement"]
+projects: ["Gold-Rush-Robotics/2"]
+assignees:
+  - dudebehinddude # assign it to PM to get a notif to sort/categorize it
+body:
+  - type: input
+    id: what
+    attributes:
+      label: WHAT IS REQUEST
+      description: What do you want to add/request? 
+      placeholder: I need the robot to do this...
+    validations:
+      required: true
+    - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is it that this gets implemented? (Take your best guess)
+      options:
+        - High (blocking major development)
+        - Medium
+        - Low

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# HAL
+# HAL (Hardware Abstraction Layer)
+
+The **Hardware Abstraction Layer (HAL)** is responsible for enabling communication between the robot's hardware and higher-level software systems. This layer interacts directly with sensors, motors, and servos, providing a standardized interface for other layers to interact with hardware components.
+
+## Goal 🏆️
+
+The goal of this project is to create a flexible and reusable hardware abstraction system that can be used current and future GRR robots with minimal changes. By standardizing how hardware is accessed and controlled, the HAL will simplify future development and integration with new components.
+
+## Overview ℹ️
+
+The HAL module provides:
+
+- **Sensor Interfaces**: Functions to read data from various sensors such as cameras, distance sensors, and more.
+- **Motor/Servo Control**: Functions to control movement by sending commands to motors and servos.
+- **Abstracted Hardware Control**: Abstracting the specific hardware details to simplify the process for the rest of the system.
+
+This repository will contain code to interface with the physical hardware and handle low-level control of robot components.
+
+## Build instructions 🛠️
+
+- This section will be updated as code gets added to this repository
+
+## Development instructions 💻️
+
+something something docker devenv something something
+
+- This section will be updated as code gets added to this repository
+
+## Structure 🗃️
+
+- This section will be updated as code gets added to this repository
+
+## License ⚖️
+
+This repository is licensed under the MIT License. See the [LICENSE](https://github.com/Gold-Rush-Robotics/hal/blob/main/LICENSE) for more info.


### PR DESCRIPTION
Adds a basic README file (70% written by ChatGPT) and 2 issue templates (1 for issues and 1 for feature requests). I can't test the issue templates to see if they work or not because I guess forks don't get an issue tab? [Here is more information](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) about how to configure issue templates and such though.